### PR TITLE
[Conda] Add recipe

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,0 +1,47 @@
+package:
+  name: occa
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  git_url: ../
+
+build:
+  number: 0
+  # Note that setting the build string to GIT_BUILD_STR will override the
+  # default value with the Python and NumPy versions. Use for development
+  # versions only.
+  #string: {{ GIT_BUILD_STR }}
+  script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - git
+  host:
+    - python
+    - numpy >=1.7
+    - setuptools >=28.0.0
+    - flake8
+    - pytest >=3.6
+    - pytest-cov
+  run:
+    - python
+    - numpy >=1.7
+
+test:
+  imports:
+    - occa
+    - occa.c
+    - occa.okl
+  requires:
+    - pytest >=3.6
+
+about:
+  home: https://libocca.org
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Portable Approach for Parallel Architectures
+  doc_url:
+  dev_url: https://github.com/libocca/occa.py


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

### Description

This PR adds a Conda recipe for OCCA. 

To build the package, simply run `conda build .` from within the `.conda` directory. The recipe was build following the guidelines in the references listed below.

This more or less resolves: https://github.com/libocca/occa/issues/114

## Build requirements
When developing the recipe, I installed several additional packages, which were needed to successfully build the package on my laptop:
``` bash
conda install pytest flake8 setuptools
conda install gcc_linux-64 gxx_linux-64
```

## References
https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs.html
https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html
https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#templating-with-jinja
https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#git-environment-variables
https://conda-forge.org/docs/maintainer/knowledge_base.html
